### PR TITLE
fix GCP deployment

### DIFF
--- a/modules/development/cluster.tf
+++ b/modules/development/cluster.tf
@@ -10,6 +10,8 @@ resource "google_container_cluster" "primary" {
   name     = var.cluster_name
   location = var.location
 
+  min_master_version = var.k8s_version
+
   master_auth {
     username = "${random_id.username.hex}"
     password = "${random_id.password.hex}"

--- a/modules/development/variables.tf
+++ b/modules/development/variables.tf
@@ -13,3 +13,7 @@ variable "node_count" {
 variable "machine_type" {
   default = "n1-standard-2"
 }
+
+variable "k8s_version" {
+  default = "1.13.6-gke.13"
+}

--- a/modules/engineering/cluster.tf
+++ b/modules/engineering/cluster.tf
@@ -10,6 +10,8 @@ resource "google_container_cluster" "primary" {
   name     = var.cluster_name
   location = var.location
 
+  min_master_version = var.k8s_version
+
   master_auth {
     username = "${random_id.username.hex}"
     password = "${random_id.password.hex}"

--- a/modules/engineering/variables.tf
+++ b/modules/engineering/variables.tf
@@ -13,3 +13,7 @@ variable "node_count" {
 variable "machine_type" {
   default = "n1-standard-2"
 }
+
+variable "k8s_version" {
+  default = "1.14.6-gke.2"
+}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -10,15 +10,6 @@ if [ "${DEPLOYMENT}" = development ] || [ "${DEPLOYMENT}" = development-runners 
     terraform init
 
     terraform apply -auto-approve
-
-
-    if [ "${DEPLOYMENT}" = development-runners ]; then
-      # https://docs.gitlab.com/runner/install/kubernetes.html
-      helm repo add gitlab https://charts.gitlab.io
-      helm repo update
-      helm upgrade --install gitlab-runner  --set gitlabUrl=https://gitlab.w3f.tech/,runnerRegistrationToken=$GITLAB_TOKEN gitlab/gitlab-runner
-    fi
-
 else
     terraform init \
               -backend-config="access_key=$SPACES_ACCESS_TOKEN" \


### PR DESCRIPTION
Towards https://github.com/w3f/infrastructure/issues/54

Still more fixes for GCP, we need the min master version value for existing clusters. Also, the gitlab-runner helm chart is not required for connecting the cluster with gitlab.