### PR TITLE
bump k8s version for w3f and community

### DIFF
--- a/modules/community/variables.tf
+++ b/modules/community/variables.tf
@@ -13,7 +13,7 @@ variable "node_count" {
 }
 
 variable "k8s_version" {
-  default = "1.14.1-do.3"
+  default = "1.16.6-do.0"
 }
 
 variable "region" {

--- a/modules/w3f/variables.tf
+++ b/modules/w3f/variables.tf
@@ -9,7 +9,7 @@ variable "node_count" {
 }
 
 variable "k8s_version" {
-  default = "1.13.4-do.0"
+  default = "1.16.6-do.0"
 }
 
 variable "region" {


### PR DESCRIPTION
Still part of https://github.com/w3f/infrastructure/issues/121

Bumps the k8s version for DOKS clusters, this way it won't try to downgrade them on next platform deployment. Tested locally with `terraform plan` (with this PR plan shows 0 changes, without them shows a downgrade).